### PR TITLE
Fix #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Virtuoso via the Skill console.
 2. Open Virtuoso
 2. Type these commands into the Skill console
     - `load("PATH-TO-IPC-SERVER")`
-    - `dumpFunctionDefinitions "<install>"` (`"<install>"` is not a placeholder, type it as is)
+    - `pyDumpFunctionDefinitions "<install>"` (`"<install>"` is not a placeholder, type it as is)
 
 **_Note:_** Generating the function definitions is very slow and will take several
 minutes. Don't cancel the command.

--- a/docs/usage/server.rst
+++ b/docs/usage/server.rst
@@ -7,16 +7,16 @@ Initially the server must be started by loading the ``python_server.il``.
 
 After that, these management commands are available in the Skill console.
 
-.. function:: killPythonServer()
+.. function:: pyKillServer()
 
     This terminates the python subprocess and thus, kills the server.
     After that, no connections from the client side can be made anymore
     and active connections will result in a :class:`BrokenPipe` exception
     the next time they are used.
 
-.. function:: reloadPythonServer(level="WARNING")
+.. function:: pyReloadServer(level="WARNING")
 
-    This calls :func:`killPythonServer` and reloads the ``python_server.il``
+    This calls :func:`pyKillServer` and reloads the ``python_server.il``
     Skill script. With this function you can effectively restart the python
     server in case it crashes.
 
@@ -32,14 +32,14 @@ After that, these management commands are available in the Skill console.
         the time for a round-trip between the client and the server is effectively
         two to three times as long!
 
-.. function:: showPythonLog(numberOfLines=10)
+.. function:: pyShowLog(numberOfLines=10)
 
     Used for debugging. This shows the logging output from the
     python server. The parameter ``numberOfLines`` controlls
     how many lines will be printed. It always refers to the **last**
     ``numberOfLines`` lines.
 
-.. function:: dumpFunctionDefinitions(filename)
+.. function:: pyDumpFunctionDefinitions(filename)
 
     This dumps all function names, parameters and documentations into the file
     given by ``filename``. These function definitions are used by the python

--- a/skillbridge/server/python_server.il
+++ b/skillbridge/server/python_server.il
@@ -1,100 +1,121 @@
-__py_filename = get_filename(piport)
-__py_withoutExtension = substring(__py_filename 1 strlen(__py_filename)-2)
-__py_moduleFolder = substring(__py_filename 1 strlen(__py_filename)-23)
-__py_installFile = strcat(__py_moduleFolder "client/definitions.txt")
-__py_python = strcat("python " __py_withoutExtension "py")
-__py_pythonLog = strcat(__py_withoutExtension "py.log")
+let((_filename _baseName _moduleFolder _installName _logName _ipc)
 
+    _filename = get_filename(piport)
+    _baseName = substring(_filename 1 strlen(_filename)-2)
+    _moduleFolder = substring(_filename 1 strlen(_filename)-23)
+    _installName = strcat(_moduleFolder "client/definitions.txt")
+    _executable = strcat("python " _baseName "py")
+    _logName = strcat(_baseName "py.log")
 
-putd('dumpFunctionDefinitions nil)
-defun(dumpFunctionDefinitions (filename)
-    names = nil
-    poport = outfile(if(filename == "<install>" __py_installFile filename))
-    total = float(length(oblist))
+    putd('pyDumpFunctionDefinitions nil)
+    defun(pyDumpFunctionDefinitions (filename)
+        let((names name total code)
+            names = nil
+            total = float(length(oblist))
+            poport = outfile(if(filename == "<install>" pyDumpFunctionDefinitions.installName filename))
 
-    for(i 1 (length(oblist) - 1)
-        ; apparently the symbol unbound is in oblist and when you assign unbound to a
-        ; variable, the variable is indeed unbound and causes an error if used, wtf skill
-        if(symbolToString(nth(i oblist)) != "unbound" then
-            name = nth(i oblist)
+            for(i 1 (length(oblist) - 1)
+                ; apparently the symbol unbound is in oblist and when you assign unbound to a
+                ; variable, the variable is indeed unbound and causes an error if used, wtf skill
+                if(symbolToString(nth(i oblist)) != "unbound" then
+                    name = nth(i oblist)
 
-            if(and(isCallable(name) substring(name 1 1) != "_") then
-                ; this is a hack, because `help(name)` does not evaluate the variable
-                ; `name` for some reason
-                printf("BEGIN FUNCTION %s\n" name)
-                code = sprintf(nil "help(%s)" name)
-                errset(evalstring(code))
-                printf("END FUNCTION %s\n\n" name)
-                names = cons(name names)
+                    if(and(isCallable(name) substring(name 1 1) != "_") then
+                        printf("BEGIN FUNCTION %s\n", name)
+                        ; this is a hack, because `help(name)` does not evaluate the variable
+                        ; `name` for some reason
+                        code = sprintf(nil "help(%s)" name)
+                        errset(evalstring(code))
+                        printf("END FUNCTION %s\n\n" name)
+                        names = cons(name names)
+                    )
+                )
+
+                if(mod(i 100) == 0 then
+                    fprintf(stdout "dumped %6.2f%% found %d functions\n" (i / total * 100) length(names))
+                )
             )
-           )
 
-        if(mod(i 100) == 0 then
-            fprintf(stdout "dumped %6.2f%% found %d functions\n" (i / total * 100) length(names))
+            close(poport)
+            poport = stdout
+            sprintf(nil "found %d functions total" length(names))
         )
     )
-    close(poport)
-    poport = stdout
-    sprintf(nil "found %d functions total" length(names))
-)
 
-putd('killPythonServer nil)
-defun(killPythonServer ()
-    ipcKillProcess(__py_ipc)
-)
+    pyDumpFunctionDefinitions.installName = _installName
 
-putd('reloadPythonServer nil)
-defun(reloadPythonServer (@optional (level "WARNING"))
-    printf("killing the old server\n")
-    killPythonServer()
-    setShellEnvVar(strcat("LOG_LEVEL=" level))
-    load(__py_filename)
+    putd('pyKillServer nil)
+    defun(pyKillServer ()
+        ipcKillProcess(pyKillServer.ipc)
+    )
+
+    putd('pyReloadServer nil)
+    defun(pyReloadServer (@optional (level "WARNING"))
+        printf("killing the old server\n")
+        pyKillServer()
+        setShellEnvVar(strcat("LOG_LEVEL=" level))
+        load(pyReloadServer.filename)
+    )
+
+    pyReloadServer.filename = _filename
+
+    putd('pyShowLog nil)
+    defun(pyShowLog (@optional (length 20))
+        let((fin line lines)
+            fin = infile(pyShowLog.logName)
+            lines = nil
+
+            for(i 1 length
+                lines = append1(lines "")
+            )
+
+            while(gets(line fin)
+                lines = cdr(append1(lines line))
+            )
+
+            foreach(line lines
+                printf("%s" line)
+            )
+            printf("")
+        )
+    )
+
+    pyShowLog.logName = _logName
+
+    putd('__pyOnData nil)
+    defun(__pyOnData (id data)
+        foreach(line parseString(data "\n")
+            let((result)
+                errset(result=evalstring(line))
+                if((errset.errset) then
+                    printf("command %L resulted in error %L\n" line errset.errset)
+                    ipcWriteProcess(__pyOnData.ipc sprintf(nil "failure %L\n" errset.errset))
+                else
+                    ipcWriteProcess(__pyOnData.ipc sprintf(nil "success %L\n" result))
+                )
+            )
+        )
+    )
+
+    putd('__pyOnError nil)
+    defun(__pyOnError (id data)
+        printf("error %L\n" data)
+    )
+
+    putd('__pyOnFinish nil)
+    defun(__pyOnFinish (id data)
+        printf("server was stopped with code %L\n" data)
+    )
+
+    _ipc = ipcBeginProcess(_executable "" '__pyOnData '__pyOnError '__pyOnFinish "python_server.log")
+
+    __pyOnData.ipc = _ipc
+    pyKillServer.ipc = _ipc
+
+    printf("Server started\n")
     printf("Available commands:\n")
-    printf("\tkillPythonServer\n")
-    printf("\treloadPythonServer [log level]\n")
-    printf("\tshowPythonLog [number of lines]\n")
+    printf("\tpyKillServer\n")
+    printf("\tpyReloadServer [logLevel]\n")
+    printf("\tpyShowLog [numberOfLines]\n")
+    printf("\tpyDumpFunctionDefinitions filename\n")
 )
-
-putd('showPythonLog nil)
-defun(showPythonLog (@optional (length 20))
-    fin = infile(__py_pythonLog)
-    lines = nil
-    for(i 1 length
-        lines = append1(lines "")
-    )
-    while(gets(line fin)
-        lines = cdr(append1(lines line))
-    )
-
-    foreach(line lines
-        printf("%s" line)
-    )
-    printf("")
-)
-
-putd('__py_onData nil)
-defun(__py_onData (id data)
-    foreach(line parseString(data "\n")
-        errset(result=evalstring(line))
-	if( (errset.errset)
-            then
-                printf("command %L resulted in error %L\n" line errset.errset)
-                ipcWriteProcess(__py_ipc sprintf(nil "failure %L\n" errset.errset))
-            else
-                ipcWriteProcess(__py_ipc sprintf(nil "success %L\n" result))
-        )
-    )
-)
-
-putd('__py_onError nil)
-defun(__py_onError (id data)
-    printf("error %L\n" data)   		
-    
-)
-
-putd('__py_onFinish nil)
-defun(__py_onFinish (id data)
-    printf("server was stopped with code %L\n" data)   		
-)
-
-__py_ipc = ipcBeginProcess(__py_python "" '__py_onData '__py_onError '__py_onFinish "python_server.log")


### PR DESCRIPTION
- All variables inside functions are marked as local (with `let`)
- Global functions have a common prefix (`py`)
- Private functions have a common prefix (`__py`)
- Documentation is updated

Closes #4 