### PR TITLE
Cache workspaces based on id

### DIFF
--- a/skillbridge/__init__.py
+++ b/skillbridge/__init__.py
@@ -8,11 +8,6 @@ except ImportError:
     warn("Failed to import the cparser. You must first build the extension module",
          UserWarning)
 
-    Workspace = None
-    loop_variable = None
-    Var = None
-    ParseError = None
-    Symbol = None
 
 __version__ = '0.9.2'
 __all__ = ['Workspace', 'loop_variable', 'Var', 'ParseError', 'Symbol']

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -31,7 +31,15 @@ def channel() -> Channel:
 
 @fixture
 def ws() -> Workspace:
-    ws = Workspace.open(WORKSPACE_ID)
+    for _ in range(10):
+        try:
+            ws = Workspace.open(WORKSPACE_ID)
+        except BlockingIOError:
+            continue
+        else:
+            break
+    else:
+        raise
     yield ws
     ws.close()
 


### PR DESCRIPTION
Closes #30 

`Workspace.open(id)` caches all workspaces based on the given id.

```python
ws1 = Workspace.open()
ws2 = Workspace.open()
ws3 = Workspace.open("stuff")
ws4 = Workspace.open("stuff")

assert ws1 is ws2
assert ws3 is ws4

assert ws1 is not ws3
```


