### PR TITLE
Fix pip install dependency conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
 - '3.6'
 - '3.7'
 before_install:
-- pip install --upgrade -r dev-requirements.txt
-- pip install --upgrade codecov
+- pip install --upgrade --upgrade-strategy eager -r dev-requirements.txt
+- pip install --upgrade --upgrade-strategy eager codecov
 install:
 - python setup.py build_ext --inplace -fv
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
 - '3.6'
 - '3.7'
 before_install:
-- pip install -r dev-requirements.txt
-- pip install codecov
+- pip install --upgrade -r dev-requirements.txt
+- pip install --upgrade codecov
 install:
 - python setup.py build_ext --inplace -fv
 script:


### PR DESCRIPTION
Some dependencies where incompatible in travis. This makes sure to always pull the latest version of all dev dependencies.