### PR TITLE
Allow multiple connections

### DIFF
--- a/docs/usage/server.rst
+++ b/docs/usage/server.rst
@@ -7,7 +7,7 @@ Initially the server must be started by loading the ``python_server.il``.
 
 After that, these management commands are available in the Skill console.
 
-.. function:: pyStartServer(id="default" logLevel="WARNING")
+.. function:: pyStartServer(id="default" logLevel="WARNING" singleMode=nil)
 
     This starts the python server. If you are only running a single instance of
     Virtuoso you can use the default id. For more instances, each server needs its own
@@ -22,6 +22,20 @@ After that, these management commands are available in the Skill console.
         The log levels ``"DEBUG"`` and ``"INFO"`` are not recommended, because then
         the time for a round-trip between the client and the server is effectively
         two to three times as long!
+
+    The ``singleMode`` parameter allows you to disable simultaneous connections to
+    the server. By default, multiple connections are allowed for convenience reasons.
+    Especially jupyter users will benefit from this, since jupyter keeps the socket
+    connections open.
+
+    .. warning::
+
+        Even when ``singleMode`` is disabled it is **never** safe to simultaneously
+        access the server. This will lead to strange errors, where variables don't
+        contain what you initially assigned to them.
+
+        In order to stay safe: **never** interleave commands from two different
+        connections.
 
 .. function:: pyKillServer()
 

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -16,6 +16,19 @@ class Workspace:
     SOCKET_TEMPLATE = '/tmp/skill-server-{}.sock'
     _var_counter = 0
 
+    db: FunctionCollection
+    dd: FunctionCollection
+    sch: FunctionCollection
+    ge: FunctionCollection
+    rod: FunctionCollection
+    le: FunctionCollection
+    via: FunctionCollection
+    pte: FunctionCollection
+    lx: FunctionCollection
+    hi: FunctionCollection
+    mae: FunctionCollection
+    get: FunctionCollection
+
     def __init__(self, channel: Channel, id: str) -> None:
         definitions = functions_by_prefix()
 

--- a/skillbridge/server/python_server.il
+++ b/skillbridge/server/python_server.il
@@ -57,7 +57,6 @@ let((_filename _baseName _moduleFolder _installName _logName)
         else
             ipcKillProcess(pyStartServer.ipc)
             pyStartServer.ipc = nil
-            deleteFile(pyStartServer.file)
             t
         )
     )
@@ -119,10 +118,12 @@ let((_filename _baseName _moduleFolder _installName _logName)
     putd('__pyOnFinish nil)
     defun(__pyOnFinish (id data)
         printf("server was stopped with code %L\n" data)
+        deleteFile(pyStartServer.file)
+        remExitProc('__pyDeleteSocketOnExit)
     )
 
     putd('pyStartServer nil)
-    defun(pyStartServer (@optional (id "default") (logLevel "WARNING"))
+    defun(pyStartServer (@optional (id "default") (logLevel "WARNING") (singleMode nil))
         if(pyStartServer.ipc != nil then
             fprintf(stderr, "server is already running\n")
             nil
@@ -134,20 +135,31 @@ let((_filename _baseName _moduleFolder _installName _logName)
                     fprintf(stderr, "Server cannot start, because %s already exists. Delete the file if you are sure that it is not in use anymore.", socketFile)
                     nil
                 else
-                    executableWithArgs = buildString(list(_executable socketFile logLevel))
+                    executableWithArgs = buildString(list(pyStartServer.exe socketFile logLevel))
+                    if(singleMode != nil then
+                        executableWithArgs = buildString(list(executableWithArgs "--single"))
+                    )
+
                     pyStartServer.ipc = ipcBeginProcess(executableWithArgs "" '__pyOnData '__pyOnError '__pyOnFinish "python_server.log")
                     pyStartServer.file = socketFile
+                    regExitBefore('__pyDeleteSocketOnExit)
                     t
                 )
             )
         )
     )
 
+    putd('__pyDeleteSocketOnExit nil)
+    defun(__pyDeleteSocketOnExit (@rest args)
+        deleteFile(pyStartServer.file)
+    )
+
     pyStartServer.ipc = nil
     pyStartServer.file = nil
+    pyStartServer.exe = _executable
 
     printf("Available commands:\n")
-    printf("\tpyStartServer [socketFile [logLevel]]\n")
+    printf("\tpyStartServer [socketFile [logLevel [singleMode]]\n")
     printf("\tpyKillServer\n")
     printf("\tpyReloadScript\n")
     printf("\tpyShowLog [numberOfLines]\n")

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -11,7 +11,7 @@ WORKSPACE_ID = '__test__'
 UNIX_SOCKET = Workspace.socket_name_for_id(WORKSPACE_ID)
 
 
-@fixture("session")
+@fixture(scope="session")
 def server() -> Virtuoso:
     v = Virtuoso(UNIX_SOCKET)
     v.start()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -36,7 +36,7 @@ class Server(Thread):
         super().__init__(daemon=True)
 
     def run(self):
-        python_server.main(UNIX_SOCKET, "DEBUG", notify=True)
+        python_server.main(UNIX_SOCKET, "DEBUG", notify=True, single=False)
 
 
 @fixture


### PR DESCRIPTION
Closes #34 

- The python server now spawns a thread for every incoming connection.
- Virtuoso deletes the socket file when closed
- The multiconnection behaviour can be disabled with the `--single` option or the `singleMode` parameter in `pyStartServer(id logLevel singleMode=nil)`

