### PR TITLE
Increment version before tagging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup, find_packages, Extension, Command
 from re import match
-from os.path import join
 
 import skillbridge
 
@@ -46,7 +45,7 @@ class TagVersion(Command):
         one_higher = '.'.join(str(i) for i in one_higher)
         new_version = input(f"Enter the new version ({one_higher}): ") or one_higher
 
-        if not match('\d+\.\d+\.\d+', new_version):
+        if not match(r'\d+\.\d+\.\d+', new_version):
             print("Version must be of this format: NUMBER.NUMBER.NUMBER")
             return
 


### PR DESCRIPTION
Closes #33 

`python setup.py tag` now works as follows:

1. Prints the current version
2. Ask for the next version (press enter to increment by 1)
3. Change the version in `skillbridge/__init__.py`
4. Commit the version change with message "bump version 'X.X.X'"
5. Tag the commit with 'releases/X.X.X' and message "release X.X.X"