### PR TITLE
Function prefix whitelist via annotations

### DIFF
--- a/skillbridge/client/extract.py
+++ b/skillbridge/client/extract.py
@@ -7,8 +7,6 @@ from warnings import warn
 from .hints import Function
 from .translator import camel_to_snake
 
-WHITELIST = set('db dd sch ge rod le via pte lx hi mae'.split())
-
 
 def _inside_body(line: str) -> bool:
     return not line.startswith('END FUNCTION')
@@ -66,11 +64,7 @@ def parse_all_function() -> List[Function]:
 
 def functions_by_prefix() -> Dict[str, List[Function]]:
     functions = parse_all_function()
-    functions = sorted(
-        f for f in functions
-        if _extract_prefix(f) in WHITELIST or
-        any(_extract_prefix(a) in WHITELIST for a in f.aliases)
-    )
+    functions.sort()
 
     return {
         (prefix or '_'): list(group)

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -18,25 +18,26 @@ class Workspace:
 
     db: FunctionCollection
     dd: FunctionCollection
-    sch: FunctionCollection
     ge: FunctionCollection
-    rod: FunctionCollection
-    le: FunctionCollection
-    via: FunctionCollection
-    pte: FunctionCollection
-    lx: FunctionCollection
-    hi: FunctionCollection
-    mae: FunctionCollection
     get: FunctionCollection
+    hi: FunctionCollection
+    le: FunctionCollection
+    lx: FunctionCollection
+    mae: FunctionCollection
+    pte: FunctionCollection
+    rod: FunctionCollection
+    sch: FunctionCollection
+    via: FunctionCollection
 
-    def __init__(self, channel: Channel, id: str) -> None:
+    def __init__(self, channel: Channel, id_: str) -> None:
         definitions = functions_by_prefix()
 
-        self._id = id
+        self._id = id_
         self._channel = channel
         self._max_transmission_length = 1_000_000
 
-        for key, definition in definitions.items():
+        for key in Workspace.__annotations__:
+            definition = definitions[key]
             value = FunctionCollection(channel, definition, self._create_remote_object)
             setattr(self, key, value)
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,5 +1,4 @@
-from skillbridge.client.extract import parse_all_function, functions_by_prefix,\
-    Function, WHITELIST
+from skillbridge.client.extract import parse_all_function, Function
 
 
 def test_parse_all():
@@ -7,24 +6,3 @@ def test_parse_all():
     assert functions
 
     assert all(isinstance(func, Function) for func in functions)
-
-
-def test_by_prefix():
-    groups = functions_by_prefix()
-
-    for group in WHITELIST:
-        assert group in groups
-
-        assert all(isinstance(func, Function) for func in groups[group])
-
-
-def test_aliases_are_mapped_even_when_prefix_not_whitelisted():
-    functions = functions_by_prefix()['get']
-
-    assert any(func.name == 'getCurrentWindow' for func in functions)
-
-
-def test_not_whitelisted_prefix_not_present():
-    functions = functions_by_prefix()['get']
-
-    assert all(func.name != 'getValue' for func in functions)


### PR DESCRIPTION
This pulls the whitelist for the function prefixes from the annotations in Workspace