### PR TITLE
Manual function registry

### DIFF
--- a/docs/examples/custom_functions.rst
+++ b/docs/examples/custom_functions.rst
@@ -1,0 +1,63 @@
+Manually Registering Functions
+==============================
+
+The ``skillbridge`` will only export functions that are documented in
+the running Vivado instance. If you need functions that are not documented there
+but still exist, you can register them manually.
+
+Let's take a look at the following example.
+
+.. code-block::
+    python
+
+    @ws.register
+    def dbCheck(d_cellview) -> None:
+        """
+        A docstring
+        """
+
+This will register the function ``dbCheck`` which takes a single argument ``d_cellview``
+and returns ``nil``. You may also write the function name in snake case: ``db_check``.
+
+.. note::
+
+    You must provide a return type annotation. Use ``None`` if you don't know the type
+    or are unsure. You also must provide a doc string which describes what the function
+    actually does.
+
+There are three ways to specify arguments.
+
+1. Positional, required arguments by naming the python parameter accordingly
+2. Positional, optional arguments by adding the type annotation ``Optional``
+3. Keyword arguments by assigning a name to the variable
+
+The next example shows all three uses
+
+.. code-block::
+    python
+
+    from typing import Optional
+
+    @ws.register
+    def myFunction(required, optional: Optional, keyword="someName") -> "someReturnValue":
+        """
+        A nice doc string, that explains the function
+        """
+
+You can use the function like this:
+
+>>> ws.my.function
+<remote function 'myFunction'>
+myFunction(
+    required
+    [ optional ]
+    [ ?someName keyword ]
+=> someReturnValue
+A nice doc string, that explains the function
+
+.. warning::
+
+    Obviously this only **registers** the function, but it does not define it
+    in Skill. If you actually call ``myFunction`` you will get the error:
+
+    ``undefined function myFunction``

--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -1,0 +1,7 @@
+Examples
+========
+
+.. toctree::
+    :glob:
+
+    *

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,18 +9,9 @@ Welcome to Python-Skill Bridge |version|
     :maxdepth: 2
     :caption: Contents:
 
-    usage/overview
-    usage/installation
-    usage/quickstart
-    usage/server
-
-    examples/basic
-    examples/multiple-instances
-    examples/inst-statistics
-    examples/lib_save
-    examples/create_path
-    reference/remote-object
-    reference/protocol
+    usage/index
+    examples/index
+    reference/index
 
 
 Indices and tables

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,0 +1,7 @@
+Reference
+=========
+
+.. toctree::
+    :glob:
+
+    *

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -1,0 +1,7 @@
+Usage
+=====
+
+.. toctree::
+    :glob:
+
+    *

--- a/skillbridge/client/extract.py
+++ b/skillbridge/client/extract.py
@@ -12,11 +12,8 @@ def _inside_body(line: str) -> bool:
     return not line.startswith('END FUNCTION')
 
 
-def _extract_prefix(f: Union[Function, str]) -> str:
-    if isinstance(f, Function):
-        name = f.name
-    else:
-        name = f
+def _extract_prefix(f: Function) -> str:
+    name = f.name
     m = match(r'([a-z]+)[A-Z]', name)
     if m is None:
         return ''

--- a/skillbridge/client/functions.py
+++ b/skillbridge/client/functions.py
@@ -23,7 +23,7 @@ class FunctionCollection:
         self._definitions[camel_to_snake(func.name)] = func
         return self
 
-    def add_by_key(self, key: str, func: Function):
+    def add_by_key(self, key: str, func: Function) -> None:
         self._definitions[key] = func
 
     def __repr__(self) -> str:

--- a/skillbridge/client/functions.py
+++ b/skillbridge/client/functions.py
@@ -23,6 +23,9 @@ class FunctionCollection:
         self._definitions[camel_to_snake(func.name)] = func
         return self
 
+    def add_by_key(self, key: str, func: Function):
+        self._definitions[key] = func
+
     def __repr__(self) -> str:
         return f"<function collection>\n{dir(self)}"
 

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -17,7 +17,7 @@ _open_workspaces: Dict[str, 'Workspace'] = {}
 
 def _register_well_known_functions(ws):
     @ws.register
-    def db_check(d_cellview: Optional) -> "t / nil":
+    def db_check(d_cellview: Optional) -> None:
         """
         Checks the integrity of the database.
         """

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Callable, Any
 from inspect import signature
 from textwrap import dedent
 
@@ -15,9 +15,9 @@ __all__ = ['Workspace']
 _open_workspaces: Dict[str, 'Workspace'] = {}
 
 
-def _register_well_known_functions(ws):
+def _register_well_known_functions(ws: 'Workspace') -> None:
     @ws.register
-    def db_check(d_cellview: Optional) -> None:
+    def db_check(d_cellview: Optional) -> None:  # type: ignore
         """
         Checks the integrity of the database.
         """
@@ -118,7 +118,7 @@ class Workspace:
         return skill_value_to_python(response, [variable], self._create_remote_object)
 
     @staticmethod
-    def _build_function(function):
+    def _build_function(function: Callable[..., Any]) -> Function:
         if not function.__doc__:
             raise RuntimeError("Function does not have a doc string.")
 
@@ -148,11 +148,11 @@ class Workspace:
             ""
         ]
 
-        doc = '\n'.join(doc) + dedent(function.__doc__)
+        doc_string = '\n'.join(doc) + dedent(function.__doc__)
 
-        return Function(snake_to_camel(function.__name__), doc, set())
+        return Function(snake_to_camel(function.__name__), doc_string, set())
 
-    def register(self, function):
+    def register(self, function: Callable[..., Any]) -> Function:
         name = camel_to_snake(function.__name__)
 
         try:
@@ -169,7 +169,7 @@ class Workspace:
             collection = FunctionCollection(self._channel, [], self._create_remote_object)
             setattr(self, prefix, collection)
 
-        function = self._build_function(function)
-        collection.add_by_key(rest, function)
+        function_tuple = self._build_function(function)
+        collection.add_by_key(rest, function_tuple)
 
-        return function
+        return function_tuple

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -1,15 +1,26 @@
-from typing import List, Dict
+from typing import List, Dict, Optional
+from inspect import signature
+from textwrap import dedent
 
 from .hints import SkillPath, Function, SkillCode, ConvertToSkill
 from .channel import Channel, UnixChannel
 from .functions import FunctionCollection
 from .extract import functions_by_prefix
 from .objects import RemoteObject
-from .translator import list_map, assign, skill_value_to_python
+from .translator import list_map, assign, skill_value_to_python, camel_to_snake
+from .translator import snake_to_camel
 
 __all__ = ['Workspace']
 
 _open_workspaces: Dict[str, 'Workspace'] = {}
+
+
+def _register_well_known_functions(ws):
+    @ws.register
+    def db_check(d_cellview: Optional) -> "t / nil":
+        """
+        Checks the integrity of the database.
+        """
 
 
 class Workspace:
@@ -42,6 +53,8 @@ class Workspace:
             setattr(self, key, value)
 
         self.user = FunctionCollection(channel, [], self._create_remote_object)
+
+        _register_well_known_functions(self)
 
     @property
     def id(self) -> str:
@@ -103,3 +116,60 @@ class Workspace:
         code = assign(variable, code)
         response = self._channel.send(code)
         return skill_value_to_python(response, [variable], self._create_remote_object)
+
+    @staticmethod
+    def _build_function(function):
+        if not function.__doc__:
+            raise RuntimeError("Function does not have a doc string.")
+
+        s = signature(function)
+
+        if s.return_annotation is s.empty:
+            raise RuntimeError("Function does not have a return annotation.")
+
+        param_doc = []
+        for p in s.parameters.values():
+            if p.default is p.empty:
+                param = p.name
+
+                if p.annotation is Optional:
+                    param = f"    [ {param} ]"
+                else:
+                    param = f"    {param}"
+            else:
+                param = f"    [ ?{p.default} {p.name} ]"
+
+            param_doc.append(param)
+
+        doc = [
+            function.__name__ + "(",
+            *param_doc,
+            f"=> {'nil' if s.return_annotation is None else s.return_annotation}",
+            ""
+        ]
+
+        doc = '\n'.join(doc) + dedent(function.__doc__)
+
+        return Function(snake_to_camel(function.__name__), doc, set())
+
+    def register(self, function):
+        name = camel_to_snake(function.__name__)
+
+        try:
+            prefix, rest = name.split('_', maxsplit=1)
+        except ValueError:
+            raise RuntimeError("Function does not have a prefix.") from None
+
+        try:
+            collection = getattr(self, prefix)
+            assert isinstance(collection, FunctionCollection)
+        except AssertionError:
+            raise RuntimeError("You cannot use that prefix.") from None
+        except AttributeError:
+            collection = FunctionCollection(self._channel, [], self._create_remote_object)
+            setattr(self, prefix, collection)
+
+        function = self._build_function(function)
+        collection.add_by_key(rest, function)
+
+        return function

--- a/skillbridge/server/python_server.py
+++ b/skillbridge/server/python_server.py
@@ -107,7 +107,7 @@ def main(socket: str, log_level: str, notify: bool, single: bool) -> None:
 
     server_class = SingleUnixServer if single else ThreadingUnixServer
 
-    with server_class(socket, Handler) as server:  # type: ignore
+    with server_class(socket, Handler) as server:
         logger.info("starting server")
         if notify:
             send_to_skill('running')


### PR DESCRIPTION
**Merge #41 first**

Closes #40 

Allows the user (and the library) to manually register known Skill functions:

```python
@ws.register
def myFunction(required, optional: Optional, keyword="someName") -> "someReturnValue":
    """
    A nice doc string, that explains the function
    """
```

This registers the function `myFunction` under the `my` prefix.

```
>>> ws.my.function
<remote function 'myFunction'>
myFunction(
    required
    [ optional ]
    [ ?someName keyword ]

=> someReturnValue
```