### PR TITLE
Show dd/db type names in object repr

### DIFF
--- a/skillbridge/client/objects.py
+++ b/skillbridge/client/objects.py
@@ -50,8 +50,12 @@ class RemoteObject(Skillable):
 
     def __str__(self) -> str:
         type_, address = self._variable[5:].split('_')
-        object_type = self.obj_type or type_
-        return f"<remote {object_type}@{address}>"
+        if type_.startswith('db'):
+            type_ = self.obj_type or type_
+        elif type_.startswith('dd'):
+            dd_type = self.type
+            type_ = dd_type.name[2:-4] if dd_type else type_
+        return f"<remote {type_}@{address}>"
 
     __repr__ = __str__
 

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -153,11 +153,12 @@ def test_property_list_is_mapped(server, ws):
 
 
 def test_object_is_mapped(server, ws):
-    server.answer_object('object', 1234, None)
+    server.answer_object('object', 1234)
     result = ws.ge.get_edit_cell_view()
 
     assert isinstance(result, RemoteObject)
-    assert 'object@1234' in str(result)
+    string = str(result)
+    assert 'object@1234' in string
 
     server.answer_success('["x","y","z"]')
     doc = result.getdoc()

--- a/tests/virtuoso.py
+++ b/tests/virtuoso.py
@@ -67,11 +67,12 @@ class Virtuoso(Thread):
                 answer = self.queue.get_nowait()
             except Empty:
                 raise RuntimeError(f"no answer available for {question!r}")
-            print("answer", answer)
             self.write(answer)
 
     def read(self):
-        readable, _, _ = select([self.server.stdout], [], [], 1)
+        # we need to wait pretty long here, because sometimes it takes really long
+        # to start the server
+        readable, _, _ = select([self.server.stdout], [], [], 10)
         if readable:
             return self.server.stdout.readline().strip()
 


### PR DESCRIPTION
This PR uses the attributes `objType` for DB objects and `type` for DD objects to print more information in the `__repr__` and `__str__` methods.

```
cell_view = ws.ge.get_edit_cell_view()
print("cell view", cell_view)
print("cell", cell_view.cell)
print("instances", cell_view.instances)
``` 

> cell view <remote cellView@0x212db61a>
> cell <remote Cell@0x251b9270>
> instances [<remote inst@0x212dae1d>, <remote inst@0x212dae1c>, <remote inst@0x212dae1b>, <remote inst@0x212dae1a>]

Closes #50 