### PR TITLE
Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 script:
 - cp tests/test_definitions.txt skillbridge/client/definitions.txt
 - flake8
+- mypy --strict skillbridge
 - pytest
 after_success:
 - codecov

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ config = dict(
     long_description_content_type="text/markdown",
     url="https://github.com/unihd-cag/skillbridge",
     packages=find_packages(),
+    package_data={'skillbridge': ['py.typed']},
     include_package_data=True,
     extras_require={
         'dev': dev_requirements

--- a/skillbridge/__init__.py
+++ b/skillbridge/__init__.py
@@ -1,16 +1,14 @@
 from os import chdir
 
 from .client.workspace import Workspace
-from .client.translator import loop_variable, Var, ParseError, Symbol
+from .client.translator import ParseError
+from .client.hints import Var, Symbol
 
 __version__ = '1.0.2'
-__all__ = [
-    'Workspace', 'loop_variable', 'Var', 'ParseError', 'Symbol',
-    'generate_static_completion'
-]
+__all__ = ['Workspace', 'Var', 'ParseError', 'Symbol', 'generate_static_completion']
 
 
-def generate_static_completion():
+def generate_static_completion() -> None:
     from subprocess import run
     from .client.extract import functions_by_prefix
     from .client.functions import name_without_prefix

--- a/skillbridge/__main__.py
+++ b/skillbridge/__main__.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 from . import generate_static_completion
 
 
-def print_skill_script_location():
+def print_skill_script_location() -> None:
     folder = dirname(abspath(__file__))
     skill_source = join(folder, 'server', 'python_server.il')
     print(skill_source)

--- a/skillbridge/client/channel.py
+++ b/skillbridge/client/channel.py
@@ -1,6 +1,6 @@
 from socket import socket, SOCK_STREAM, AF_UNIX
 from select import select
-from typing import Iterable
+from typing import Iterable, Union, Any
 
 
 class Channel:
@@ -16,7 +16,7 @@ class Channel:
     def flush(self) -> None:
         raise NotImplementedError
 
-    def try_repair(self):
+    def try_repair(self) -> Any:
         raise NotImplementedError
 
     @property
@@ -63,7 +63,7 @@ class UnixChannel(Channel):
             remaining -= len(data)
             yield data
 
-    def _send_only(self, data: str):
+    def _send_only(self, data: str) -> None:
         byte = data.encode()
 
         if len(byte) > self._max_transmission_length:
@@ -88,7 +88,7 @@ class UnixChannel(Channel):
             self.socket.sendall(length)
             self.socket.sendall(byte)
 
-    def _receive_only(self):
+    def _receive_only(self) -> str:
         try:
             received_length_raw = self.socket.recv(10)
         except KeyboardInterrupt:
@@ -114,7 +114,7 @@ class UnixChannel(Channel):
         self._send_only(data)
         return self._receive_only()
 
-    def try_repair(self):
+    def try_repair(self) -> Union[Exception, str]:
         try:
             length = int(self.socket.recv(10))
             message = b''.join(self._receive_all(length))

--- a/skillbridge/client/extract.py
+++ b/skillbridge/client/extract.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Iterator, List, Dict, Optional, Set, Tuple, Union
+from typing import Iterable, Iterator, List, Dict, Optional, Set, Tuple
 from itertools import takewhile, groupby
 from re import match
 from os.path import dirname, abspath, join

--- a/skillbridge/client/functions.py
+++ b/skillbridge/client/functions.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from .hints import Replicator, Definition, Function, ConvertToSkill, SkillCode
+from .hints import Replicator, Definition, Function, SkillCode, Skill
 from .channel import Channel
 from .translator import camel_to_snake, call, skill_value_to_python
 
@@ -47,13 +47,13 @@ class RemoteFunction:
         self._replicator = replicator
         self._function = func
 
-    def __call__(self, *args: ConvertToSkill, **kwargs: ConvertToSkill) -> ConvertToSkill:
+    def __call__(self, *args: Skill, **kwargs: Skill) -> Skill:
         command = self.lazy(*args, **kwargs)
         result = self._channel.send(command)
 
         return skill_value_to_python(result, self._replicator)
 
-    def lazy(self, *args: ConvertToSkill, **kwargs: ConvertToSkill) -> SkillCode:
+    def lazy(self, *args: Skill, **kwargs: Skill) -> SkillCode:
         name = self._function.name
         RemoteFunction._counter += 1
 
@@ -67,9 +67,9 @@ class RemoteFunction:
 
 
 class RemoteMethod:
-    def __init__(self, instance: ConvertToSkill, func: RemoteFunction) -> None:
+    def __init__(self, instance: Skill, func: RemoteFunction) -> None:
         self._instance = instance
         self._function = func
 
-    def __call__(self, *args: ConvertToSkill, **kwargs: ConvertToSkill) -> ConvertToSkill:
+    def __call__(self, *args: Skill, **kwargs: Skill) -> Skill:
         return self._function(self._instance, *args, **kwargs)

--- a/skillbridge/client/functions.py
+++ b/skillbridge/client/functions.py
@@ -2,7 +2,7 @@ from typing import List
 
 from .hints import Replicator, Definition, Function, ConvertToSkill, SkillCode
 from .channel import Channel
-from .translator import camel_to_snake, assign, call, skill_value_to_python
+from .translator import camel_to_snake, call, skill_value_to_python
 
 
 def name_without_prefix(name: str) -> str:
@@ -49,8 +49,6 @@ class RemoteFunction:
 
     def __call__(self, *args: ConvertToSkill, **kwargs: ConvertToSkill) -> ConvertToSkill:
         command = self.lazy(*args, **kwargs)
-        variable = f'__call_{self._function.name}_{self._counter}'
-        command = assign(variable, command)
         result = self._channel.send(command)
 
         return skill_value_to_python(result, self._replicator)

--- a/skillbridge/client/hints.py
+++ b/skillbridge/client/hints.py
@@ -1,9 +1,16 @@
-from typing import Union, List, Tuple, Callable, NewType, NamedTuple, Dict, Set
+from typing import Union, List, Callable, NewType, NamedTuple, Dict, Set, Tuple
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Protocol
+else:
+    class Protocol:
+        pass
+
 
 __all__ = [
-    'Number',
-    'SkillComponent', 'SkillCode', 'Skillable',
-    'ConvertToSkill', 'ConvertToSkillFlat',
+    'Number', 'Symbol', 'Var',
+    'SkillComponent', 'SkillCode', 'Skill',
     'Replicator',
     'Definition', 'Function'
 ]
@@ -13,18 +20,59 @@ SkillComponent = Union[int, str]
 SkillCode = NewType('SkillCode', str)
 
 
-Function = NamedTuple('Function', [
-    ('name', str), ('description', str), ('aliases', Set[str])
-])
+class Function(NamedTuple):
+    name: str
+    description: str
+    aliases: Set[str]
+
+
 Definition = List[Function]
 
 
-class Skillable:
+class SupportsReprSkill(Protocol):
     def __repr_skill__(self) -> SkillCode: ...
 
 
-ConvertToSkillFlat = Union[Skillable, Number, str, bool, None]
-PropList = Dict[str, ConvertToSkillFlat]
-ConvertToSkill = Union[ConvertToSkillFlat, List[ConvertToSkillFlat], PropList]
+Skill = Union[
+    SupportsReprSkill, Number, str, bool, None,
+    'SkillList', 'SkillDict', 'SkillTuple'
+]
+Replicator = Callable[[str], Skill]
 
-Replicator = Callable[[str], ConvertToSkill]
+
+class SkillList(List[Skill]):
+    pass
+
+
+class SkillTuple(Tuple[Skill, ...]):
+    pass
+
+
+class SkillDict(Dict[str, Skill]):
+    pass
+
+
+class Symbol(NamedTuple):
+    name: str
+
+    def __repr_skill__(self) -> SkillCode:
+        return SkillCode(f"'{self.name}")
+
+    def __str__(self) -> str:
+        return f"Symbol({self.name})"
+
+    def __repr__(self) -> str:
+        return f"Symbol({self.name!r})"
+
+
+class Var(NamedTuple):
+    name: str
+
+    def __repr_skill__(self) -> SkillCode:
+        return SkillCode(self.name)
+
+    def __str__(self) -> str:
+        return f"Var({self.name})"
+
+    def __repr__(self) -> str:
+        return f"Var({self.name!r})"

--- a/skillbridge/client/hints.py
+++ b/skillbridge/client/hints.py
@@ -1,7 +1,7 @@
 from typing import Union, List, Tuple, Callable, NewType, NamedTuple, Dict, Set
 
 __all__ = [
-    'Number', 'BBox', 'Transform',
+    'Number',
     'SkillComponent', 'SkillCode', 'Skillable',
     'ConvertToSkill', 'ConvertToSkillFlat',
     'Replicator',
@@ -9,8 +9,6 @@ __all__ = [
 ]
 
 Number = Union[int, float]
-BBox = List[List[Number]]
-Transform = Tuple[Tuple[Number, Number], str, Number]
 SkillComponent = Union[int, str]
 SkillCode = NewType('SkillCode', str)
 

--- a/skillbridge/client/objects.py
+++ b/skillbridge/client/objects.py
@@ -1,6 +1,6 @@
 from typing import Any, List
 
-from .hints import SkillCode, Skillable
+from .hints import SkillCode
 from .channel import Channel
 from .extract import method_map
 from .functions import RemoteFunction, RemoteMethod
@@ -28,7 +28,7 @@ def is_jupyter_magic(attribute: str) -> bool:
     return attribute in ignore
 
 
-class RemoteObject(Skillable):
+class RemoteObject:
     _attributes = {'_channel', '_variable', '_methods'}
     _method_map = method_map()
 
@@ -40,7 +40,7 @@ class RemoteObject(Skillable):
         self._methods = RemoteObject._method_map.get(object_type, {})
 
     @property
-    def skill_id(self):
+    def skill_id(self) -> str:
         return self._variable.split('_')[-1]
 
     def _replicate(self, variable: str) -> 'RemoteObject':

--- a/skillbridge/client/translator.py
+++ b/skillbridge/client/translator.py
@@ -7,12 +7,6 @@ from .hints import Replicator, SkillCode, ConvertToSkill
 from .hints import Skillable
 
 
-SKILL_TO_PYTHON = {
-    't': True,
-    'nil': None
-}
-
-
 class Symbol(Skillable, namedtuple('Symbol', 'name')):
     def __str__(self) -> str:
         return f"Symbol({self.name})"
@@ -85,13 +79,6 @@ def _not_implemented(string: str) -> Replicator:
     return inner
 
 
-def skill_literal_to_value(string_or_object: Any) -> Any:
-    if isinstance(string_or_object, str):
-        replicator = _not_implemented(string_or_object)
-        return skill_value_to_python(string_or_object, replicator)
-    return string_or_object
-
-
 def skill_help(obj: SkillCode) -> SkillCode:
     parts = ' '.join((
         f'{obj}->?',
@@ -117,31 +104,12 @@ def skill_setattr(obj: SkillCode, key: str, value: Any) -> SkillCode:
     return SkillCode(f'{code} = {value}')
 
 
-def assign(variable: str, expression: SkillCode) -> SkillCode:
-    return SkillCode(f'{variable} = {expression}')
-
-
 def call(func_name: str, *args: ConvertToSkill, **kwargs: ConvertToSkill) -> SkillCode:
     args_code = ' '.join(map(python_value_to_skill, args))
     kw_keys = map(snake_to_camel, kwargs)
     kw_values = map(python_value_to_skill, kwargs.values())
     kwargs_code = ' '.join(f'?{key} {value}' for key, value in zip(kw_keys, kw_values))
     return SkillCode(f'{func_name}({args_code} {kwargs_code})')
-
-
-def call_assign(variable_name: str, function_name: str,
-                *args: ConvertToSkill, **kwargs: ConvertToSkill) -> SkillCode:
-    return assign(variable_name, call(function_name, *args, **kwargs))
-
-
-def check_function(function_name: str) -> SkillCode:
-    return SkillCode(f"__check = isCallable('{function_name})")
-
-
-def list_map(expression: SkillCode, data: List[ConvertToSkill]) -> SkillCode:
-    skill_data = python_value_to_skill(data)  # type: ignore
-    variable = loop_variable.name
-    return SkillCode(f'mapcar(lambda(({variable}) {expression}) {skill_data})')
 
 
 def build_skill_path(components: Iterable[str]) -> SkillCode:

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -1,13 +1,13 @@
-from typing import List, Dict, Optional, Callable, Any
+from typing import Dict, Optional, Callable, Any
 from inspect import signature
 from textwrap import dedent
 
-from .hints import Function, SkillCode, ConvertToSkill
+from .hints import Function, SkillCode
 from .channel import Channel, UnixChannel
 from .functions import FunctionCollection
 from .extract import functions_by_prefix
 from .objects import RemoteObject
-from .translator import list_map, assign, skill_value_to_python, camel_to_snake
+from .translator import camel_to_snake
 from .translator import snake_to_camel
 
 __all__ = ['Workspace']
@@ -231,14 +231,6 @@ class Workspace:
     @max_transmission_length.setter
     def max_transmission_length(self, value: int) -> None:
         self._channel.max_transmission_length = value
-
-    def map(self, expr: SkillCode, data: List[ConvertToSkill]) -> ConvertToSkill:
-        code = list_map(expr, data)
-        variable = f'__ws_map_{self._var_counter}'
-        Workspace._var_counter += 1
-        code = assign(variable, code)
-        response = self._channel.send(code)
-        return skill_value_to_python(response, self._create_remote_object)
 
     @staticmethod
     def _build_function(function: Callable[..., Any]) -> Function:

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -34,12 +34,10 @@ class Workspace:
     adt: FunctionCollection
     aed: FunctionCollection
     ael: FunctionCollection
-    ael: FunctionCollection
     ahdl: FunctionCollection
     alm: FunctionCollection
     amse: FunctionCollection
     anc: FunctionCollection
-    ann: FunctionCollection
     ann: FunctionCollection
     ans: FunctionCollection
     ap: FunctionCollection
@@ -56,11 +54,9 @@ class Workspace:
     ccp: FunctionCollection
     cdf: FunctionCollection
     cds: FunctionCollection
-    cds: FunctionCollection
     ci: FunctionCollection
     ciw: FunctionCollection
     conn: FunctionCollection
-    cpf: FunctionCollection
     cpf: FunctionCollection
     cpfe: FunctionCollection
     cph: FunctionCollection
@@ -75,7 +71,6 @@ class Workspace:
     dl: FunctionCollection
     dm: FunctionCollection
     dmb: FunctionCollection
-    dr: FunctionCollection
     dr: FunctionCollection
     drd: FunctionCollection
     drpl: FunctionCollection
@@ -95,7 +90,6 @@ class Workspace:
     hdb: FunctionCollection
     he: FunctionCollection
     hi: FunctionCollection
-    hnl: FunctionCollection
     hnl: FunctionCollection
     hsm: FunctionCollection
     icc: FunctionCollection
@@ -130,7 +124,6 @@ class Workspace:
     pipo: FunctionCollection
     po: FunctionCollection
     ps: FunctionCollection
-    pte: FunctionCollection
     pte: FunctionCollection
     rdb: FunctionCollection
     rde: FunctionCollection
@@ -289,5 +282,5 @@ class Workspace:
 
         return function_tuple
 
-    def try_repair(self):
+    def try_repair(self) -> Any:
         return self._channel.try_repair()

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -6,7 +6,7 @@ from skillbridge.client.objects import RemoteObject
 from tests.virtuoso import Virtuoso
 
 from skillbridge.client.channel import UnixChannel, Channel
-from skillbridge import Workspace, loop_variable
+from skillbridge import Workspace
 
 
 WORKSPACE_ID = '__test__'
@@ -257,9 +257,9 @@ def test_function_produces_same_code_as_method(server, ws):
     server.answer_success('"/path/to/thing"')
 
     ws.db.full_path(db)
-    _, from_function = server.last_question.split('=')
+    from_function = server.last_question
     db.db_full_path()
-    _, from_method = server.last_question.split('=')
+    from_method = server.last_question
 
     assert from_function == from_method
 
@@ -294,20 +294,6 @@ def test_max_transmission_length_is_honored(server, ws):
 
 def test_flush_does_no_harm(server, ws):
     ws.flush()
-
-
-def test_skill_side_for_loop(server, ws):
-    server.answer_object('cell', 1234)
-    server.answer_success("[10,10,10,10,10]")
-
-    cell = ws.ge.get_edit_cell_view()
-    assert 'geGetEditCellView' in server.last_question
-
-    windows = ws.map(ws.ge.get_cell_view_window.lazy(loop_variable), [cell] * 5)
-    last = server.last_question
-    assert 'mapcar(' in last and 'geGetCellViewWindow' in last
-
-    assert windows == [10, 10, 10, 10, 10]
 
 
 def test_add_function_manually(server, ws):

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -8,14 +8,14 @@ from skillbridge.client.hints import SkillCode
 from skillbridge.client.translator import snake_to_camel, camel_to_snake,\
     python_value_to_skill, skill_value_to_python,\
     skill_setattr, skill_help, skill_help_to_list,\
-    skill_getattr, Var, build_python_path, call
-from skillbridge import Symbol
+    skill_getattr, build_python_path, call
+from skillbridge import Symbol, Var
 
 
 floats = floats(allow_infinity=False, allow_nan=False)
 ints = integers(min_value=-2**63, max_value=2**63-1)
-asciis = text(ascii_uppercase + ascii_lowercase + ascii_letters)
-symbols = text(ascii_uppercase + ascii_lowercase + ascii_letters, min_size=4)
+asciis = text(ascii_uppercase + ascii_lowercase + ascii_letters, max_size=99)
+symbols = text(ascii_uppercase + ascii_lowercase + ascii_letters, min_size=4, max_size=99)
 simple_types = floats | ints | none() | asciis
 
 


### PR DESCRIPTION
Closes #64 

- add `mypy` to CI again
- remove for loop on Skill side feature (`ws.map`)
- repair type hinting for types that are convertible to Skill
- dont create variables when calling functions (should have been removed when Skill parser was removed)
- some prefixes where present twice in the Workspace annotations
