### PR TITLE
Add static completion stub file generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ env/*
 skillbridge/server/python_server.py.log
 skillbridge/server/python_server.log
 skillbridge/client/definitions*
+skillbridge/client/workspace.pyi
 
 test.py
 test.ipynb

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ Virtuoso via the Skill console.
     - `load("PATH-TO-IPC-SERVER")`
     - `pyDumpFunctionDefinitions "<install>"` (`"<install>"` is not a placeholder, type it as is)
 
-**_Note:_** Generating the function definitions is very slow and will take several
-minutes. Don't cancel the command.
+**_Note:_** Generating the function definitions may take several seconds to complete.
+
+After that you can also generate the static completion stub files. This is useful for code completion
+in certain IDEs (e.g. PyCharm)
+
+- Type `python -m skillbridge -g` into your shell.
 
 ### Updating
 

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -17,7 +17,7 @@ Source Installation
 2. ``cd skillbridge``
 3. ``pip install -e .``
 
-Verify installation
+Verify Installation
 ~~~~~~~~~~~~~~~~~~~
 
 ``python -m skillbridge``

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -22,6 +22,32 @@ You can obtain the correct path from the python library like this:
 
 Read more about :ref:`server`.
 
+One-time setup
+--------------
+
+Before you can use the python library you must generate the list of function
+available in Skill. Type this once into the Skill console,
+after you loaded the Skill script.
+
+.. code-block:: lisp
+
+    pyDumpFunctionDefinitions "<install>"
+
+After that you can generate the static completion stub file. That is useful
+for IDEs like PyCharm. Type this once into a terminal after you generated the
+function definitions.
+
+.. code-block:: sh
+
+    python -m skillbridge -g
+
+
+.. note::
+
+    Generating the static completion stub files requires a tool called ``stubgen``.
+    You can install it alongside the python static type check ``mypy`` by typing
+    ``pip install mypy`` into your shell.
+
 Connecting to the Server
 ------------------------
 

--- a/skillbridge/__init__.py
+++ b/skillbridge/__init__.py
@@ -1,5 +1,33 @@
+from os import chdir
+
 from .client.workspace import Workspace
 from .client.translator import loop_variable, Var, ParseError, Symbol
 
 __version__ = '1.0.2'
-__all__ = ['Workspace', 'loop_variable', 'Var', 'ParseError', 'Symbol']
+__all__ = [
+    'Workspace', 'loop_variable', 'Var', 'ParseError', 'Symbol',
+    'generate_static_completion'
+]
+
+
+def generate_static_completion():
+    from subprocess import run
+    from .client.extract import functions_by_prefix
+    from .client.functions import name_without_prefix
+    from pathlib import Path
+
+    client = Path(__file__).parent.absolute() / 'client'
+    chdir(client)
+    run(['stubgen', 'workspace.py', '-o', '.'])
+
+    functions = functions_by_prefix()
+    with open('workspace.pyi', 'a') as fout:
+        for key, values in functions.items():
+            fout.write(f'    class {key}:\n')
+
+            for func in values:
+                if func.name == 'return':
+                    continue
+
+                name = name_without_prefix(func.name)
+                fout.write(f'        def {name}(*args, **kwargs): ...\n')

--- a/skillbridge/__main__.py
+++ b/skillbridge/__main__.py
@@ -1,7 +1,25 @@
 from os.path import abspath, dirname, join
+from argparse import ArgumentParser
+
+from . import generate_static_completion
 
 
-if __name__ == '__main__':
+def print_skill_script_location():
     folder = dirname(abspath(__file__))
     skill_source = join(folder, 'server', 'python_server.il')
     print(skill_source)
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser('skillbridge', description="""
+    Without arguments, prints the location of the skill script.
+    The correct location is required for the load command.
+    """)
+    parser.add_argument('-g', '--generate', help="generate static completion file",
+                        action='store_true', default=False)
+    args = parser.parse_args()
+
+    if args.generate:
+        generate_static_completion()
+    else:
+        print_skill_script_location()

--- a/skillbridge/client/functions.py
+++ b/skillbridge/client/functions.py
@@ -5,7 +5,7 @@ from .channel import Channel
 from .translator import camel_to_snake, assign, call, skill_value_to_python
 
 
-def _name_without_prefix(name: str) -> str:
+def name_without_prefix(name: str) -> str:
     *_, name = camel_to_snake(name).split('_', maxsplit=1)
     return name
 
@@ -16,7 +16,7 @@ class FunctionCollection:
         self._channel = channel
         self._replicate = replicator
         self._definitions = {
-            _name_without_prefix(func.name): func for func in definition
+            name_without_prefix(func.name): func for func in definition
         }
 
     def __iadd__(self, func: Function) -> 'FunctionCollection':


### PR DESCRIPTION
Closes #66 

You can now generate a stub file `workspace.pyi` that contains all Skill functions from `definitions.txt`.

Generate it like this:

```
python -m skillbridge -g
```

*Requires `mypy`*