### PR TITLE
Dont produce invalid syntax in stub file

### DIFF
--- a/skillbridge/__init__.py
+++ b/skillbridge/__init__.py
@@ -15,6 +15,10 @@ def generate_static_completion():
     from .client.extract import functions_by_prefix
     from .client.functions import name_without_prefix
     from pathlib import Path
+    from re import fullmatch
+    from keyword import iskeyword
+
+    ident = r'[a-zA-Z_][a-zA-Z0-9_]*'
 
     client = Path(__file__).parent.absolute() / 'client'
     chdir(client)
@@ -23,11 +27,20 @@ def generate_static_completion():
     functions = functions_by_prefix()
     with open('workspace.pyi', 'a') as fout:
         for key, values in functions.items():
+            if not fullmatch(ident, key) or iskeyword(key):
+                continue
+
             fout.write(f'    class {key}:\n')
+            lines = 0
 
             for func in values:
-                if func.name == 'return':
+                name = name_without_prefix(func.name)
+
+                if not fullmatch(ident, name) or iskeyword(name):
                     continue
 
-                name = name_without_prefix(func.name)
+                lines += 1
                 fout.write(f'        def {name}(*args, **kwargs): ...\n')
+
+            if not lines:
+                fout.write('        pass\n')


### PR DESCRIPTION
This removes identifiers that are invalid in python:

*Examples*:

```
class class:
    ...

class something:
    def return(...): ...
```