### PR TITLE
Add cli for ease-of-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the `--user`  option if you don't want to install it systemwide.
 Before you can use the Skill bridge you must generate the function definitions from
 Virtuoso via the Skill console.
 
-1. Type `skillbridge` into your shell to acquire the correct `PATH-TO-IPC-SERVER`
+1. Type `skillbridge path` into your shell to acquire the correct `PATH-TO-IPC-SERVER`
 2. Open Virtuoso
 2. Type these commands into the Skill console
     - `load("PATH-TO-IPC-SERVER")`
@@ -41,7 +41,7 @@ Virtuoso via the Skill console.
 After that you can also generate the static completion stub files. This is useful for code completion
 in certain IDEs (e.g. PyCharm)
 
-- Type `python -m skillbridge -g` into your shell.
+- Type `skillbridge generate` into your shell.
 
 ### Updating
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the `--user`  option if you don't want to install it systemwide.
 Before you can use the Skill bridge you must generate the function definitions from
 Virtuoso via the Skill console.
 
-1. Type `python -m skillbridge` into your shell to acquire the correct `PATH-TO-IPC-SERVER`
+1. Type `skillbridge` into your shell to acquire the correct `PATH-TO-IPC-SERVER`
 2. Open Virtuoso
 2. Type these commands into the Skill console
     - `load("PATH-TO-IPC-SERVER")`

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -20,4 +20,6 @@ Source Installation
 Verify Installation
 ~~~~~~~~~~~~~~~~~~~
 
-``python -m skillbridge``
+``skillbridge``
+
+This should print the path to the Skill server script and the command to load it.

--- a/docs/usage/installation.rst
+++ b/docs/usage/installation.rst
@@ -22,4 +22,4 @@ Verify Installation
 
 ``skillbridge``
 
-This should print the path to the Skill server script and the command to load it.
+This should print the help message of the ``skillbridge`` CLI tool.

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -17,7 +17,7 @@ You can obtain the correct path from the python library like this:
 
 .. code-block:: sh
 
-    python -m skillbridge
+    skillbridge
 
 
 Read more about :ref:`server`.
@@ -39,7 +39,7 @@ function definitions.
 
 .. code-block:: sh
 
-    python -m skillbridge -g
+    skillbridge -g
 
 
 .. note::

--- a/docs/usage/quickstart.rst
+++ b/docs/usage/quickstart.rst
@@ -17,7 +17,7 @@ You can obtain the correct path from the python library like this:
 
 .. code-block:: sh
 
-    skillbridge
+    skillbridge path
 
 
 Read more about :ref:`server`.
@@ -39,7 +39,7 @@ function definitions.
 
 .. code-block:: sh
 
-    skillbridge -g
+    skillbridge generate
 
 
 .. note::
@@ -47,6 +47,19 @@ function definitions.
     Generating the static completion stub files requires a tool called ``stubgen``.
     You can install it alongside the python static type check ``mypy`` by typing
     ``pip install mypy`` into your shell.
+
+
+If you have another working installation of the ``skillbridge`` you can export its definitions
+and import them into your new installation
+
+.. code-block:: sh
+
+    # in the old environment
+    skillbridge export /absolute/path/to/temporary/file.txt
+
+    # in the new environment
+    skillbridge import /absolute/path/to/temporary/file.txt
+
 
 Connecting to the Server
 ------------------------

--- a/docs/usage/server.rst
+++ b/docs/usage/server.rst
@@ -3,7 +3,7 @@
 The Python Server
 =================
 
-Initially the server script must be run by loading the ``python_server.il``. (Type ``skillbridge``
+Initially the server script must be run by loading the ``python_server.il``. (Type ``skillbridge path``
 into your terminal to get the correct paths).
 
 .. code-block::

--- a/docs/usage/server.rst
+++ b/docs/usage/server.rst
@@ -3,7 +3,8 @@
 The Python Server
 =================
 
-Initially the server script must be run by loading the ``python_server.il``.
+Initially the server script must be run by loading the ``python_server.il``. (Type ``skillbridge``
+into your terminal to get the correct paths).
 
 .. code-block::
     lisp

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,11 @@ config = dict(
     extras_require={
         'dev': dev_requirements
     },
+    entry_points={
+        'console_scripts': [
+            'skillbridge = skillbridge.__main__:main'
+        ]
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",

--- a/skillbridge/__main__.py
+++ b/skillbridge/__main__.py
@@ -65,9 +65,12 @@ def import_definitions(path: Path) -> None:
 
 
 def main() -> None:
-    parser = ArgumentParser('skillbridge', description="""
+    parser = ArgumentParser(
+        'skillbridge',
+        description="""
         CLI utility for the various skillbridge management commands
-        """)
+        """,
+    )
 
     sub = parser.add_subparsers(title='commands', dest='command')
 
@@ -86,7 +89,7 @@ def main() -> None:
         'path': (path, print_skill_script_location),
         'generate': (generate, generate_static_completion),
         'export': (export, lambda: export_definitions(args.path)),
-        'import': (imp, lambda: import_definitions(args.path))
+        'import': (imp, lambda: import_definitions(args.path)),
     }
 
     sub_parser, func = commands[args.command]

--- a/skillbridge/__main__.py
+++ b/skillbridge/__main__.py
@@ -18,7 +18,7 @@ def print_skill_script_location() -> None:
     print(f'load("{escaped}")')
 
 
-def main():
+def main() -> None:
     parser = ArgumentParser('skillbridge', description="""
         Without arguments, prints the location of the skill script.
         The correct location is required for the load command.

--- a/skillbridge/__main__.py
+++ b/skillbridge/__main__.py
@@ -1,7 +1,11 @@
 from os.path import abspath, dirname, join
 from argparse import ArgumentParser
+from pathlib import Path
+from shutil import copy
+from typing import Dict, Tuple, Any, Callable, Optional
 
 from . import generate_static_completion
+from .client.extract import functions_by_prefix
 
 
 def print_skill_script_location() -> None:
@@ -18,19 +22,78 @@ def print_skill_script_location() -> None:
     print(f'load("{escaped}")')
 
 
+def show_status() -> None:
+    prefixes = functions_by_prefix()
+    function_count = sum(len(collection) for collection in prefixes.values())
+
+    if prefixes:
+        print(f"There are {function_count} functions in {len(prefixes)} prefixes")
+    else:
+        print("No function definitions are exported")
+
+
+def export_definitions(path: Path) -> None:
+    if not path.is_absolute():
+        raise RuntimeError("You must enter an absolute path")
+    if path.is_dir():
+        path /= 'definitions.txt'
+
+    if path.exists():
+        if input("{} already exists, overwrite? [yN]").lower() != 'y':
+            exit()
+
+    definitions = Path(__file__).parent / 'client' / 'definitions.txt'
+
+    copy(definitions, path)
+    print("copied")
+
+
+def import_definitions(path: Path) -> None:
+    if not path.is_absolute():
+        raise RuntimeError("You must enter an absolute path")
+    if path.is_dir():
+        path /= 'definitions.txt'
+
+    definitions = Path(__file__).parent / 'client' / 'definitions.txt'
+
+    if definitions.exists():
+        if input("definitions already exist, overwrite? [yN]").lower() != 'y':
+            exit()
+
+    copy(path, definitions)
+    show_status()
+
+
 def main() -> None:
     parser = ArgumentParser('skillbridge', description="""
-        Without arguments, prints the location of the skill script.
-        The correct location is required for the load command.
+        CLI utility for the various skillbridge management commands
         """)
-    parser.add_argument('-g', '--generate', help="generate static completion file",
-                        action='store_true', default=False)
+
+    sub = parser.add_subparsers(title='commands', dest='command')
+
+    path = sub.add_parser('path', help="show the path to the skill script")
+    generate = sub.add_parser('generate', help="generate static completion file")
+    status = sub.add_parser('status', help="show the number of exported function definitions")
+    export = sub.add_parser('export', help="export the function definitions into a text file")
+    export.add_argument('path', help="The absolute path for the exported file", type=Path)
+    imp = sub.add_parser('import', help="import the function definitions from a file")
+    imp.add_argument('path', help="The absolute path for the exported file", type=Path)
     args = parser.parse_args()
 
-    if args.generate:
-        generate_static_completion()
-    else:
-        print_skill_script_location()
+    commands: Dict[Optional[str], Tuple[Any, Callable[[], None]]] = {
+        None: (parser, parser.print_help),
+        'status': (status, show_status),
+        'path': (path, print_skill_script_location),
+        'generate': (generate, generate_static_completion),
+        'export': (export, lambda: export_definitions(args.path)),
+        'import': (imp, lambda: import_definitions(args.path))
+    }
+
+    sub_parser, func = commands[args.command]
+    try:
+        func()
+    except RuntimeError as e:
+        sub_parser.error(str(e))
 
 
 if __name__ == '__main__':

--- a/skillbridge/__main__.py
+++ b/skillbridge/__main__.py
@@ -7,27 +7,31 @@ from . import generate_static_completion
 def print_skill_script_location() -> None:
     folder = dirname(abspath(__file__))
     skill_source = join(folder, 'server', 'python_server.il')
-    print(skill_source.replace('\\', '\\\\'))
+    escaped = repr(skill_source)[1:-1]
+
+    print("Path to Skill server script:")
+    print(escaped)
+
+    print()
+
+    print("Type this into the Skill console:")
+    print(f'load("{escaped}")')
 
 
-if __name__ == '__main__':
-    parser = ArgumentParser(
-        'skillbridge',
-        description="""
-    Without arguments, prints the location of the skill script.
-    The correct location is required for the load command.
-    """,
-    )
-    parser.add_argument(
-        '-g',
-        '--generate',
-        help="generate static completion file",
-        action='store_true',
-        default=False,
-    )
+def main():
+    parser = ArgumentParser('skillbridge', description="""
+        Without arguments, prints the location of the skill script.
+        The correct location is required for the load command.
+        """)
+    parser.add_argument('-g', '--generate', help="generate static completion file",
+                        action='store_true', default=False)
     args = parser.parse_args()
 
     if args.generate:
         generate_static_completion()
     else:
         print_skill_script_location()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -8,8 +8,8 @@ from skillbridge.client.translator import Symbol
 
 
 def test_reports_skill_server_correctly():
-    out = check_output('python -m skillbridge'.split())
-    assert exists(out.strip())
+    out = check_output('python -m skillbridge path'.split())
+    assert exists(out.splitlines()[1].strip())
 
 
 def test_cannot_use_abc():


### PR DESCRIPTION
Closes #81 

- [x] `python -m skillbridge` can now also be used with just `skillbridge`
- [x] show path to skill script
- [x] show function definitions status
- [x] export definitions
- [x] import definitions
