### PR TITLE
Capture warnings and replay

### DIFF
--- a/skillbridge/client/translator.py
+++ b/skillbridge/client/translator.py
@@ -1,6 +1,7 @@
 from typing import NoReturn, Any, List, Iterable, cast
 from re import sub
 from json import dumps
+from warnings import warn_explicit
 
 from .hints import Replicator, SkillCode, Skill, Symbol
 
@@ -13,9 +14,17 @@ def _raise_error(message: str) -> NoReturn:
     raise ParseError(message)
 
 
+def _show_warning(message: str, result: Any) -> Any:
+    for i, line in enumerate(message.splitlines(keepends=False)):
+        warn_explicit(line.lstrip("*WARNING*"), UserWarning, "Skill response", i)
+
+    return result
+
+
 def skill_value_to_python(string: str, replicate: Replicator) -> Skill:
     return eval(  # type: ignore
-        string, {'Remote': replicate, 'Symbol': Symbol, 'error': _raise_error}
+        string,
+        {'Remote': replicate, 'Symbol': Symbol, 'error': _raise_error, 'warning': _show_warning},
     )
 
 

--- a/skillbridge/server/python_server.il
+++ b/skillbridge/server/python_server.il
@@ -90,13 +90,17 @@ let((_filename _baseName _moduleFolder _installName _logName)
     putd('__pyOnData nil)
     defun(__pyOnData (id data)
         foreach(line parseString(data "\n")
-            let((result)
-                errset(result=evalstring(line))
+            let((result capturedWarning pythonCode)
+                capturedWarning = __pyCaptureWarnings(errset(result=evalstring(line)))
                 if((errset.errset) then
                     printf("command %L resulted in error %L\n" line errset.errset)
                     ipcWriteProcess(pyStartServer.ipc sprintf(nil "failure %L\n" errset.errset))
                 else
-                    ipcWriteProcess(pyStartServer.ipc sprintf(nil "success %s\n" __pySkillToPython(result)))
+                    pythonCode = __pySkillToPython(result)
+                    if((capturedWarning != "") then
+                        pythonCode = sprintf(nil "warning(%L, %s)" capturedWarning pythonCode)
+                    )
+                    ipcWriteProcess(pyStartServer.ipc sprintf(nil "success %s\n" pythonCode))
                 )
             )
         )
@@ -169,6 +173,23 @@ let((_filename _baseName _moduleFolder _installName _logName)
         rexCompile("^[_a-zA-Z]+[:@][x0-9a-fA-F]+$")
         __pySaveToVariableAndReturn(thing)
         )))))
+    )
+
+    defmacro(__pyCaptureWarnings (@rest body)
+        `let(((tempPort outstring()))
+            unwindProtect(
+                {
+                    let(((woport tempPort))
+                        ,@body
+                        ; next two lines are to force final warning to be flushed
+                        warn("")
+                        getWarn()
+                    )
+                    getOutstring(tempPort)
+                }
+                close(tempPort)
+            )
+        )
     )
 
     putd('pyStartServer nil)

--- a/skillbridge/server/python_server.il
+++ b/skillbridge/server/python_server.il
@@ -175,6 +175,7 @@ let((_filename _baseName _moduleFolder _installName _logName)
         )))))
     )
 
+    putd('__pyCaptureWarnings nil)
     defmacro(__pyCaptureWarnings (@rest body)
         `let(((tempPort outstring()))
             unwindProtect(

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Optional
 from os import unlink
 
@@ -379,3 +380,16 @@ def test_use_current_workspace(server, ws):
 
     with raises(RuntimeError):
         current_workspace.ge.get_edit_cell_view()
+
+
+def test_warning_is_printed(server, ws):
+    server.answer_success('warning("This is a warning", 1234)')
+
+    with warnings.catch_warnings(record=True) as w:
+        result = ws.ge.get_edit_cell_view()
+
+    assert len(w) == 1
+    assert w[0].category == UserWarning
+    assert "This is a warning" in str(w[0].message)
+
+    assert result == 1234


### PR DESCRIPTION
Closes #86 

1. Captures warnings on the Skill side with `__pyCaptureWarnings`
2. Wraps the result object in a call to `warning`. I.e. Skill server sends `warning("This is a warning", 1234)` where `1234` is the result of the Skill function.
3. The Python client implements the `warning` function by showing the warning message to the user and simply passing through the result.

```python
>>> ws.rod.create_rect()
```

> Skill response:0: UserWarning:  (ROD-1023) rodCreateRect: ?cvId argument is not a valid database Id - nil
> Skill response:1: UserWarning:  (ROD-1001) rodCreateRect: command failed