### PR TITLE
Add pass through translator and workspace

### DIFF
--- a/skillbridge/test/__init__.py
+++ b/skillbridge/test/__init__.py
@@ -1,3 +1,3 @@
-from .channel import DummyWorkspace
+from .workspace import DummyWorkspace, PassWorkspace
 
-__all__ = ['DummyWorkspace']
+__all__ = ['DummyWorkspace', 'PassWorkspace']

--- a/skillbridge/test/channel.py
+++ b/skillbridge/test/channel.py
@@ -1,9 +1,7 @@
-from re import match
 from typing import Any, Deque
 from collections import deque
 
 from ..client.channel import Channel
-from ..client.workspace import Workspace
 
 
 class DummyChannel(Channel):
@@ -32,27 +30,3 @@ class DummyChannel(Channel):
 
     def try_repair(self) -> Any:
         pass
-
-
-class DummyWorkspace(Workspace):
-    def __init__(self) -> None:
-        self._test_channel = DummyChannel()
-        super().__init__(self._test_channel, 'test')
-
-    def prepare_warning(self, obj: Any, message: str) -> None:
-        self._test_channel.inputs.append(f'warning({message!r}, {obj!r})')
-
-    def prepare(self, obj: Any) -> None:
-        self._test_channel.inputs.append(repr(obj))
-
-    def prepare_error(self, message: str) -> None:
-        self._test_channel.inputs.append(f"error({message!r})")
-
-    def pop_request(self) -> str:
-        return self._test_channel.outputs.popleft()
-
-    def pop_match(self, pattern: str) -> bool:
-        return match(pattern, self.pop_request()) is not None
-
-    def prepare_remote(self, name: str) -> None:
-        self._test_channel.inputs.append(f'Remote("__py_remote_{name}")')

--- a/skillbridge/test/translator.py
+++ b/skillbridge/test/translator.py
@@ -1,0 +1,10 @@
+from ..client.hints import Skill, SkillCode
+from ..client.translator import Translator
+
+
+class PassTranslator(Translator):
+    def encode(self, value: Skill) -> SkillCode:
+        return value  # type: ignore
+
+    def decode(self, code: str) -> Skill:
+        return code

--- a/skillbridge/test/workspace.py
+++ b/skillbridge/test/workspace.py
@@ -1,0 +1,54 @@
+from typing import Any
+from re import match
+
+from ..client.workspace import Workspace
+from .channel import DummyChannel
+from .translator import PassTranslator
+
+
+class DummyWorkspace(Workspace):
+    def __init__(self) -> None:
+        self._test_channel = DummyChannel()
+        super().__init__(self._test_channel, 'test')
+
+    def prepare_warning(self, obj: Any, message: str) -> None:
+        self._test_channel.inputs.append(f'warning({message!r}, {obj!r})')
+
+    def prepare(self, obj: Any) -> None:
+        self._test_channel.inputs.append(repr(obj))
+
+    def prepare_error(self, message: str) -> None:
+        self._test_channel.inputs.append(f"error({message!r})")
+
+    def pop_request(self) -> str:
+        return self._test_channel.outputs.popleft()
+
+    def pop_match(self, pattern: str) -> bool:
+        return match(pattern, self.pop_request()) is not None
+
+    def prepare_remote(self, name: str) -> None:
+        self._test_channel.inputs.append(f'Remote("__py_remote_{name}")')
+
+
+class PassWorkspace(Workspace):
+    """
+    A test workspace that simply passes through all objects
+
+    This uses a custom translator that actually does not translate anything
+
+    This is useful for sending arbitrary objects through the channel
+    """
+
+    def __init__(self) -> None:
+        self._test_channel = DummyChannel()
+        self._test_translator = PassTranslator()
+        super().__init__(self._test_channel, 'test', self._test_translator)
+
+    def prepare(self, obj: Any) -> None:
+        self._test_channel.inputs.append(obj)
+
+    def pop_request(self) -> str:
+        return self._test_channel.outputs.popleft()
+
+    def pop_match(self, pattern: str) -> bool:
+        return match(pattern, self.pop_request()) is not None

--- a/tests/test_test_channel.py
+++ b/tests/test_test_channel.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from pytest import fixture, raises, warns
 
-from skillbridge.test import DummyWorkspace
+from skillbridge.test import DummyWorkspace, PassWorkspace
 from skillbridge import ParseError
 
 
@@ -22,6 +22,20 @@ def ws() -> DummyWorkspace:
         """
         find any inst
         """
+
+    return w
+
+
+@fixture
+def passws() -> PassWorkspace:
+    w = PassWorkspace()
+
+    @w.register
+    def user_call(x) -> Any:
+        """
+        just pass
+        """
+        return x
 
     return w
 
@@ -56,3 +70,23 @@ def test_warning(ws):
 
     with warns(UserWarning, match="deprecated"):
         assert ws.test.add_one(100) == 101
+
+
+def test_pass_works(passws):
+    passws.prepare(Ellipsis)
+    assert passws.user.call()
+
+    class UserDefined:
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+        def __repr__(self):
+            return "user defined"
+
+        def __str__(self):
+            return "user defined"
+
+    u = UserDefined(123)
+    passws.prepare(u)
+
+    assert passws.user.call() is u


### PR DESCRIPTION
Closes #108 

- Add a `Translator` interface that replaces the `translator` module interface
- Implement the default translator that uses the module level functions
- Implement a pass through translator that does not translate anything (for testing)
- Implement a pass through workspace that uses the dummy channel and the pass through translator

```python

ws = PassWorkspace()


class MyClass:
    ...

o = MyClass()
ws.prepare(o)
assert ws.user.call_any_function() is o
```