### PR TITLE
Fix #112

### DIFF
--- a/skillbridge/client/objects.py
+++ b/skillbridge/client/objects.py
@@ -37,12 +37,12 @@ class RemoteObject:
         self._variable = SkillCode(variable)
         self._translate = translator
 
-        object_type, _ = variable[5:].split('_', maxsplit=1)
+        object_type, _ = variable[5:].rsplit('_', maxsplit=1)
         self._methods = RemoteObject._method_map.get(object_type, {})
 
     @property
     def skill_id(self) -> int:
-        return int(self._variable[5:].split('_', maxsplit=1)[1], 0)
+        return int(self._variable[5:].rsplit('_', maxsplit=1)[1], 0)
 
     @property
     def skill_parent_type(self) -> str:

--- a/skillbridge/server/python_server.il
+++ b/skillbridge/server/python_server.il
@@ -149,10 +149,14 @@ let((_filename _baseName _moduleFolder _installName _logName)
                 variableName = sprintf(nil "__py_%s_%s" objectType address)
                 set(stringToSymbol(variableName) thing)
                 sprintf(nil "Remote(%L)" variableName)
+            else if(otherp(thing) then
+                variableSymbol = gensym("__py_OTHER_")
+                set(variableSymbol thing)
+                sprintf(nil "Remote(%L)" symbolToString(variableSymbol))
             else
                 sprintf(nil "error(%L)" repr)
                 printf("I COULD NOT PARSE %L\n" repr)
-            )
+            ))
         )
     )
 


### PR DESCRIPTION
Closes #112

`gensym(PREFIX)` creates a random symbol with a given prefix. That is ideal as a variable name for things we cannot parse.