### PR TITLE
Close #116

### DIFF
--- a/skillbridge/test/channel.py
+++ b/skillbridge/test/channel.py
@@ -1,6 +1,7 @@
-from typing import Any, Deque
-from collections import deque
+from typing import Any, Deque, Dict, Callable, Union
+from collections import deque, defaultdict
 
+from .translator import FunctionCall
 from ..client.channel import Channel
 
 
@@ -10,16 +11,35 @@ class DummyChannel(Channel):
 
         self.outputs: Deque[str] = deque()
         self.inputs: Deque[str] = deque()
+        self.functions: Dict[str, Callable[..., Any]] = {}
+        self.function_outputs: Dict[str, Deque[Any]] = defaultdict(deque)
 
-    def send(self, data: str) -> str:
+    def _try_function(self, data: Union[str, FunctionCall]) -> str:
+        if not isinstance(data, FunctionCall):
+            raise ValueError
+
+        func = self.functions[data.name]
+        self.function_outputs[data.name].append(data)
+        return func(data)
+
+    def _try_queue(self, data: str) -> str:
         try:
-            response = self.inputs.popleft()
+            result = self.inputs.popleft()
         except IndexError:
             short_data = data if len(data) < 100 else data[:100] + "..."
             raise RuntimeError(
                 f"No input provided for TestChannel: request was {short_data}"
             ) from None
-        self.outputs.append(data)
+        else:
+            self.outputs.append(data)
+            return result
+
+    def send(self, data: str) -> str:
+        try:
+            response = self._try_function(data)
+        except (ValueError, KeyError):
+            response = self._try_queue(data)
+
         return response
 
     def close(self) -> None:

--- a/skillbridge/test/channel.py
+++ b/skillbridge/test/channel.py
@@ -14,7 +14,7 @@ class DummyChannel(Channel):
         self.functions: Dict[str, Callable[..., Any]] = {}
         self.function_outputs: Dict[str, Deque[Any]] = defaultdict(deque)
 
-    def _try_function(self, data: Union[str, FunctionCall]) -> str:
+    def _try_function(self, data: Union[str, FunctionCall]) -> Any:
         if not isinstance(data, FunctionCall):
             raise ValueError
 
@@ -34,7 +34,7 @@ class DummyChannel(Channel):
             self.outputs.append(data)
             return result
 
-    def send(self, data: str) -> str:
+    def send(self, data: str) -> Any:
         try:
             response = self._try_function(data)
         except (ValueError, KeyError):

--- a/skillbridge/test/translator.py
+++ b/skillbridge/test/translator.py
@@ -1,5 +1,13 @@
+from typing import NamedTuple, Tuple, Any, Dict, cast
+
 from ..client.hints import Skill, SkillCode
 from ..client.translator import Translator
+
+
+class FunctionCall(NamedTuple):
+    name: str
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
 
 
 class PassTranslator(Translator):
@@ -8,3 +16,7 @@ class PassTranslator(Translator):
 
     def decode(self, code: str) -> Skill:
         return code
+
+    @staticmethod
+    def encode_call(func_name: str, *args: Skill, **kwargs: Skill) -> SkillCode:
+        return cast(SkillCode, FunctionCall(func_name, args, kwargs))

--- a/skillbridge/test/workspace.py
+++ b/skillbridge/test/workspace.py
@@ -50,7 +50,7 @@ class PassWorkspace(Workspace):
     def pop_request(self) -> str:
         return self._test_channel.outputs.popleft()
 
-    def pop_function_request(self, name: str) -> str:
+    def pop_function_request(self, name: str) -> Any:
         return self._test_channel.function_outputs[name].popleft()
 
     def pop_match(self, pattern: str) -> bool:
@@ -60,7 +60,7 @@ class PassWorkspace(Workspace):
         self._test_channel.functions[name] = func
 
     def prepare_function_value(self, name: str, value: Any) -> None:
-        def func(*args, **kwargs):
+        def func(*args: Any, **kwargs: Any) -> Any:
             return value
 
         self._test_channel.functions[name] = func

--- a/skillbridge/test/workspace.py
+++ b/skillbridge/test/workspace.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Callable
 from re import match
 
 from ..client.workspace import Workspace
@@ -50,5 +50,17 @@ class PassWorkspace(Workspace):
     def pop_request(self) -> str:
         return self._test_channel.outputs.popleft()
 
+    def pop_function_request(self, name: str) -> str:
+        return self._test_channel.function_outputs[name].popleft()
+
     def pop_match(self, pattern: str) -> bool:
         return match(pattern, self.pop_request()) is not None
+
+    def prepare_function(self, name: str, func: Callable[..., Any]) -> None:
+        self._test_channel.functions[name] = func
+
+    def prepare_function_value(self, name: str, value: Any) -> None:
+        def func(*args, **kwargs):
+            return value
+
+        self._test_channel.functions[name] = func

--- a/tests/test_test_channel.py
+++ b/tests/test_test_channel.py
@@ -90,3 +90,23 @@ def test_pass_works(passws):
     passws.prepare(u)
 
     assert passws.user.call() is u
+
+
+def test_pass_function_based_prepare(passws):
+    window_arg = None
+
+    def get_current_window(arg):
+        nonlocal window_arg
+        window_arg = arg.args[0]
+        return 'window'
+
+    passws.prepare_function_value('geGetEditCellView', (1, 2, 3))
+    passws.prepare_function('hiGetCurrentWindow', get_current_window)
+
+    assert passws.ge.get_edit_cell_view() == (1, 2, 3)
+    assert passws.ge.get_edit_cell_view() == (1, 2, 3)
+    assert passws.hi.get_current_window(123) == 'window'
+    assert window_arg == 123
+    assert passws.hi.get_current_window(234) == 'window'
+    assert window_arg == 234
+    assert passws.ge.get_edit_cell_view() == (1, 2, 3)


### PR DESCRIPTION
You can now prepare dummy responses based on the function calls. Additionally the function calls are not translated anymore.

```python
>>> PassTranslator.encode_call('geGetEditCellView', 'arg1', 'arg2', kwarg1=1, kwarg2=2)
FunctionCall(name='geGetEditCellView', args=('arg1', 'arg2'), kwargs={'kwarg1': 1, 'kwarg2': 2})

>>> passws.prepare_function_value('geGetEditCellView', 'cell-view')
>>> passws.ge.get_edit_cell_view()
'cell-view'

>>> passws.prepare_function('geGetEditCellView', print)
>>> passws.ge.get_edit_cell_view()
# prints: FunctionCall(name='geGetEditCellView', args=(), kwargs={})