### PR TITLE
Update python_server.py

### DIFF
--- a/skillbridge/server/python_server.py
+++ b/skillbridge/server/python_server.py
@@ -9,7 +9,7 @@ from argparse import ArgumentParser
 
 import logging
 
-LOG_FILE = __file__ + '.log'
+LOG_FILE = 'python_server.log'
 LOG_FORMAT = '%(asctime)s %(levelname)s %(message)s'
 LOG_DATE_FORMAT = '%d.%m.%Y %H:%M:%S'
 LOG_LEVEL = WARNING


### PR DESCRIPTION
skillbridge/server/python_server.py
  line12: LOG_FILE = __file__ + '.log' 
              * Changed to LOG_FILE = 'python_server.log'
              * Reason: the __file__ variable produces permission errors when installed in the central location.