### PR TITLE
Add way to disable snake-case translation on object access

### DIFF
--- a/docs/examples/raw.rst
+++ b/docs/examples/raw.rst
@@ -1,0 +1,22 @@
+.. _raw:
+
+Disable camelCase translation
+=============================
+
+
+Sometimes it is useful to disable the automatic translation
+from snake_case to camelCase when accessing attributes.
+
+.. code-block:: python
+   
+   from skillbrige import Workspace
+
+   ws = Workspace.open()
+   thing = ws.prefix.some_function_that_returns_an_object()
+
+   print(thing.snake_case)
+   # this translates to thing->snakeCase
+
+   print(thing['snake_case'])
+   # this translates to thing->snake_case
+

--- a/skillbridge/client/objects.py
+++ b/skillbridge/client/objects.py
@@ -101,11 +101,19 @@ class RemoteObject:
         result = self._send(self._translate.encode_getattr(self._variable, key))
         return self._translate.decode(result)
 
+    def __getitem__(self, item: str) -> Any:
+        result = self._send(self._translate.encode_getattr(self._variable, item, lambda x: x))
+        return self._translate.decode(result)
+
     def __setattr__(self, key: str, value: Any) -> None:
         if key in RemoteObject._attributes:
             return super().__setattr__(key, value)
 
         result = self._send(self._translate.encode_setattr(self._variable, key, value))
+        self._translate.decode(result)
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        result = self._send(self._translate.encode_setattr(self._variable, key, value, lambda x: x))
         self._translate.decode(result)
 
     def getdoc(self) -> str:

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -428,3 +428,27 @@ def test_globals_raises_when_attribute_is_invalid(server, ws):
     g = ws.globals('prefix')
     with raises(AttributeError):
         print(g.__wat__)
+
+
+def test_raw_object_access(server, ws):
+    server.answer_object('object', 22)
+
+    x = ws.db.get_stuff()
+
+    server.answer_success('123')
+    i = x.abc_def
+    assert i == 123
+    assert server.last_question == "__py_object_22->abcDef"
+
+    server.answer_success('234')
+    i = x['abc_def']
+    assert i == 234
+    assert server.last_question == "__py_object_22->abc_def"
+
+    server.answer_success('True')
+    x.abc_def = 345
+    assert server.last_question == "__py_object_22->abcDef = 345"
+
+    server.answer_success('True')
+    x['abc_def'] = 456
+    assert server.last_question == "__py_object_22->abc_def = 456"


### PR DESCRIPTION
Adds this syntax (Issue #187):

```python
ws = Workspace.open()
obj = ws.get.some_object()

print(obj['a_snake_case_name'])
# obj->a_snake_case_name

obj['a_snake_case_name'] = 123
# obj->a_snake_case_name= 123
```