### PR TITLE
fix initialization failure bug

### DIFF
--- a/skillbridge/server/python_server.il
+++ b/skillbridge/server/python_server.il
@@ -31,7 +31,7 @@ let((_filename _baseName _moduleFolder _logDirectory _executable)
 
     putd('pyShowLog nil)
     defun(pyShowLog (@optional (length 20) "x")
-        let((fin line (lines declare(lines[length]) (ptr 0)))
+        let((fin line (lines declare(lines[length])) (ptr 0))
             fin = infile(pyShowLog.logName)
 
             while(gets(line fin)


### PR DESCRIPTION
Fixed a bug where the  "skillbridge/server/python_server.il" was throwing a "let improper bind" error pointing to the "pyShowLog" function.  One of the closing parentheses was in the wrong location.

This bug was causing it to fail to load but now it loads as expected.