### PR TITLE
Fix internal close command collision

### DIFF
--- a/skillbridge/client/channel.py
+++ b/skillbridge/client/channel.py
@@ -147,6 +147,7 @@ class TcpChannel(Channel):
             ) from None
 
         if not received_length_raw:
+            breakpoint()
             raise RuntimeError("The server unexpectedly died")
         received_length = int(received_length_raw)
         response = b''.join(self._receive_all(received_length)).decode()
@@ -167,7 +168,7 @@ class TcpChannel(Channel):
 
     def close(self) -> None:
         if self.connected:
-            self.socket.sendall(b'         5close')
+            self.socket.sendall(b'         5$close')
             self.socket.close()
             self.connected = False
 

--- a/skillbridge/client/channel.py
+++ b/skillbridge/client/channel.py
@@ -147,7 +147,6 @@ class TcpChannel(Channel):
             ) from None
 
         if not received_length_raw:
-            breakpoint()
             raise RuntimeError("The server unexpectedly died")
         received_length = int(received_length_raw)
         response = b''.join(self._receive_all(received_length)).decode()

--- a/skillbridge/client/workspace.py
+++ b/skillbridge/client/workspace.py
@@ -37,15 +37,6 @@ current_workspace: Workspace
 current_workspace = _no_workspace
 
 
-def _register_well_known_functions(ws: Workspace) -> None:
-    @ws.register
-    def db_check(d_cellview: Any) -> None:
-        """
-        Checks the integrity of the database.
-        """
-        _ = d_cellview
-
-
 _unbound = Symbol('unbound')
 
 
@@ -200,8 +191,6 @@ class Workspace:
             setattr(self, key, value)
 
         self.user = FunctionCollection(channel, 'user', self._translator)
-
-        _register_well_known_functions(self)
 
     def _prepare_default_translator(self) -> DefaultTranslator:
         translator = DefaultTranslator()

--- a/skillbridge/server/python_server.py
+++ b/skillbridge/server/python_server.py
@@ -125,7 +125,7 @@ class Handler(StreamRequestHandler):
 
         logger.debug(f"received {len(command)} bytes")
 
-        if command.startswith(b'close'):
+        if command.startswith(b'$close'):
             logger.debug(f"client {self.client_address} disconnected")
             return False
         logger.debug(f"got data {command[:1000].decode()}")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from time import sleep
 from warnings import warn
 
-from pytest import fixture, raises, skip, mark
+from pytest import fixture, mark, raises, skip
 
 from skillbridge import LazyList, RemoteObject, RemoteTable, SkillCode, Symbol, Var, Workspace
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from time import sleep
 from warnings import warn
 
-from pytest import fixture, raises, skip
+from pytest import fixture, raises, skip, mark
 
 from skillbridge import LazyList, RemoteObject, RemoteTable, SkillCode, Symbol, Var, Workspace
 
@@ -236,11 +236,32 @@ def test_run_script_blocks_when_requested(ws: Workspace) -> None:
     assert ws['plus'](Var(variable), 1) == 43
 
 
+@mark.skip
 def test_form_vectors_have_dir(ws: Workspace) -> None:
     form = ws.hi.get_current_form()
     assert 'button_layout' in dir(form)
 
 
+@mark.skip
 def test_form_vectors_have_getattr(ws: Workspace) -> None:
     form = ws.hi.get_current_form()
     assert isinstance(form.button_layout, list)
+
+
+def test_outstring(ws: Workspace) -> None:
+    outstring = ws['outstring']
+    get_outstring = ws['getOutstring']
+    close = ws['close']
+    fprintf = ws['fprintf']
+
+    s = outstring()
+    assert get_outstring(s) == ""  # noqa: PLC1901
+
+    assert fprintf(s, "Hello ")
+    assert get_outstring(s) == "Hello "
+
+    assert fprintf(s, "World")
+    assert get_outstring(s) == "Hello World"
+
+    assert close(s)
+    assert get_outstring(s) is None


### PR DESCRIPTION
Internally we use the string `close` to close the connection of a workspace with the server. Unfortunately this is also a valid python request.

This PR changes the internal command to `$close`. This is neither valid Python code nor valid SKILL code so it cannot be sent by accident.

Closes #257 