### PR TITLE
Fix close command with hardcoded length

### DIFF
--- a/skillbridge/client/channel.py
+++ b/skillbridge/client/channel.py
@@ -167,7 +167,7 @@ class TcpChannel(Channel):
 
     def close(self) -> None:
         if self.connected:
-            self.socket.sendall(b'         5$close')
+            self.socket.sendall(b'         6$close')
             self.socket.close()
             self.connected = False
 


### PR DESCRIPTION
On close the client sent `$close` with a hard-coded length of `5`.

The length should be `6`