### PR TITLE
Docstrings and parameters for generate

### DIFF
--- a/skillbridge/__init__.py
+++ b/skillbridge/__init__.py
@@ -112,7 +112,24 @@ def generate_static_completion() -> None:
                     continue
 
                 lines = True
-                fout.write(f'        {func}: staticmethod\n')
+                
+                doc_string :str = getattr(value, func).__str__()
+                args = doc_string[doc_string.find('('): doc_string.find(')') + 1].split('\n')
+
+                a = []
+                symbols = ['[', ']', '(', ')', '{', '}', '=', '|']  
+                for i, arg in enumerate(args):
+                    if any(s in arg for s in symbols) or len(arg) <= 2:
+                        pass
+                    else:
+                        a.append(args[i].strip('...').strip('<').strip('>').strip("'").strip())
+                        
+                a = ', '.join(a)
+                fout.write(f'      def {func}(self{", " if a else ""}{a}):\n')
+                fout.write('            """')
+                fout.write(f'            {doc_string}\n')
+                fout.write('            """\n')
+                fout.write('            pass\n')
 
             if not lines:
                 fout.write('        pass\n')

--- a/skillbridge/__init__.py
+++ b/skillbridge/__init__.py
@@ -113,21 +113,11 @@ def generate_static_completion() -> None:
 
                 lines = True
                 
-                doc_string :str = getattr(value, func).__str__()
-                args = doc_string[doc_string.find('('): doc_string.find(')') + 1].split('\n')
-
-                a = []
-                symbols = ['[', ']', '(', ')', '{', '}', '=', '|']  
-                for i, arg in enumerate(args):
-                    if any(s in arg for s in symbols) or len(arg) <= 2:
-                        pass
-                    else:
-                        a.append(args[i].strip('...').strip('<').strip('>').strip("'").strip())
+                doc_string = getattr(value, func).__str__()
                         
-                a = ', '.join(a)
-                fout.write(f'      def {func}(self{", " if a else ""}{a}):\n')
+                fout.write(f'        {func}: staticmethod\n')
                 fout.write('            """')
-                fout.write(f'            {doc_string}\n')
+                fout.write(f'            {doc_string}')
                 fout.write('            """\n')
                 fout.write('            pass\n')
 


### PR DESCRIPTION
I am working on adding parameters and docstrings to the generate function. Would this be useful for the main branch? Here is a snipet from workspace.pyi

``` python
    class abe:
      def blockages_from_cell_view(self, t_layerName, o_outLayer, g_queue):
            """             
abeBlockagesFromCellView(
t_layerName
o_outLayer
g_queue
[ ?maskColor g_maskColor ] 
)
=> o_abeLayer / nil
 
Copies blockages from the specified layer in the current ABE
session cellview to a new or existing ABE layer. Optional arguments
restrict the copied blockages to the specified ABE layer. This
function can be run immediately or added to the queue.

            """
            pass
```